### PR TITLE
Update To Dot Net 5 and Make Reference Types available in the store

### DIFF
--- a/src/NetRx.Store.Monitor.Extension/NetRx.Store.Monitor.Extension.csproj
+++ b/src/NetRx.Store.Monitor.Extension/NetRx.Store.Monitor.Extension.csproj
@@ -26,7 +26,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetRx.Store.Monitor.Extension</RootNamespace>
     <AssemblyName>NetRx.Store.Monitor.Extension</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>

--- a/src/NetRx.Store.Monitor.Extension/NetRx.Store.Monitor.Extension.csproj
+++ b/src/NetRx.Store.Monitor.Extension/NetRx.Store.Monitor.Extension.csproj
@@ -26,7 +26,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetRx.Store.Monitor.Extension</RootNamespace>
     <AssemblyName>NetRx.Store.Monitor.Extension</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>

--- a/src/NetRx.Store.Monitor.Extension/Properties/AssemblyInfo.cs
+++ b/src/NetRx.Store.Monitor.Extension/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/src/NetRx.Store.Monitor.Extension/app.config
+++ b/src/NetRx.Store.Monitor.Extension/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/NetRx.Store.Monitor.Extension/app.config
+++ b/src/NetRx.Store.Monitor.Extension/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/src/NetRx.Store.Monitor.Shared/NetRx.Store.Monitor.Shared.csproj
+++ b/src/NetRx.Store.Monitor.Shared/NetRx.Store.Monitor.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
 

--- a/src/NetRx.Store.Monitor.Shared/NetRx.Store.Monitor.Shared.csproj
+++ b/src/NetRx.Store.Monitor.Shared/NetRx.Store.Monitor.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
 

--- a/src/NetRx.Store.Monitor.Shared/NetRx.Store.Monitor.Shared.csproj
+++ b/src/NetRx.Store.Monitor.Shared/NetRx.Store.Monitor.Shared.csproj
@@ -6,7 +6,7 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
 
     <PackageId>NetRx.Store.Monitor.Shared</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Vitalii Ilchenko</Authors>
     <Description>Includes library which allows to attach NetRx.Store Monitor tool to an application at a runtime</Description>
     <RepositoryUrl>https://github.com/ilchenkob/NetRx.Store</RepositoryUrl>

--- a/src/NetRx.Store.Tests/NetRx.Store.Tests.csproj
+++ b/src/NetRx.Store.Tests/NetRx.Store.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetRx.Store.Tests/NetRx.Store.Tests.csproj
+++ b/src/NetRx.Store.Tests/NetRx.Store.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetRx.Store.Tests/NetRx.Store.Tests.csproj
+++ b/src/NetRx.Store.Tests/NetRx.Store.Tests.csproj
@@ -1,15 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.core" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetRx.Store.Tests/State/Actions/TestStateActions.cs
+++ b/src/NetRx.Store.Tests/State/Actions/TestStateActions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using NetRx.Store;
 
 namespace NetRx.Store.Tests.State.TestStateActions
@@ -12,6 +13,14 @@ namespace NetRx.Store.Tests.State.TestStateActions
     {
         public SetItemsAction(List<string> payload) : base(payload)
         {
+        }
+    }
+    
+    public class SetReferenceObjectAction : Action<ReferenceObect> 
+    {
+        public SetReferenceObjectAction(ReferenceObect payload)  :base(payload)
+        {
+
         }
     }
 }

--- a/src/NetRx.Store.Tests/State/Reducers/TestStateReducer.cs
+++ b/src/NetRx.Store.Tests/State/Reducers/TestStateReducer.cs
@@ -21,6 +21,13 @@ namespace NetRx.Store.Tests.State.Reducers
             state.Items = action.Payload.ToImmutableList();
             return state;
         }
+
+        public TestState Reduce(TestState state, TestStateActions.SetReferenceObjectAction action)
+        {
+            ReduceCalls.Add(action.GetType().FullName);
+            state.ReferenceObect = action.Payload;
+            return state;
+        }
     }
 
     public class SecondaryTestStateReducer : Reducer<SecondaryTestState>

--- a/src/NetRx.Store.Tests/State/States/TestState.cs
+++ b/src/NetRx.Store.Tests/State/States/TestState.cs
@@ -25,6 +25,13 @@ namespace NetRx.Store.Tests.State
         };
     }
 
+    public class ReferenceObect
+    {
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+    }
+
     public struct TestState
     {
         public int Id { get; set; }
@@ -39,13 +46,17 @@ namespace NetRx.Store.Tests.State
 
         public ImmutableList<string> Items { get; set; }
 
+        public ReferenceObect ReferenceObect { get;set; }
+
         public static TestState Initial => new TestState
         {
             Id = 1,
             Name = "empty_name",
             Amount = 0.7m,
             IsEnabled = true,
-            SubState = SubState.Initial
+            SubState = SubState.Initial,
+            ReferenceObect = new ReferenceObect()
+            
         };
     }
 

--- a/src/NetRx.Store.Tests/Store/StoreTest.cs
+++ b/src/NetRx.Store.Tests/Store/StoreTest.cs
@@ -159,16 +159,13 @@ namespace NetRx.Store.Tests
 
             var disposable = store.Select<TestState, ReferenceObect>(f=> f.ReferenceObect)
                 .Subscribe(f => selectedObect = f);
-           
+                       
             store.Dispatch(new SetReferenceObjectAction(newObject));
 
             disposable.Dispose();
 
             Assert.Same(newObject, selectedObect);
-            
-           
+                      
         }
-
-
     }
 }

--- a/src/NetRx.Store.Tests/Store/StoreTest.cs
+++ b/src/NetRx.Store.Tests/Store/StoreTest.cs
@@ -4,8 +4,11 @@ using NetRx.Store.Tests.State;
 using NetRx.Store.Tests.State.Effects;
 using NetRx.Store.Tests.State.Reducers;
 using NetRx.Store.Tests.State.TestStateActions;
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Xunit;
 
 namespace NetRx.Store.Tests
@@ -22,18 +25,6 @@ namespace NetRx.Store.Tests
             Assert.NotNull(exception);
             Assert.IsType<InvalidStateTypeException>(exception);
             Assert.Contains(nameof(InvalidTypeState), exception.Message);
-        }
-
-        [Fact]
-        public void WithState_Should_Throw_InvalidStatePropertyTypeException_When_Reference_property_type_passed()
-        {
-            var exception = Record.Exception(
-                () => Store.Create().WithState(new InvalidPropertyTypeState(), new InvalidPropertyTypeStateReducer())
-            );
-
-            Assert.NotNull(exception);
-            Assert.IsType<InvalidStatePropertyTypeException>(exception);
-            Assert.Contains(nameof(InvalidPropertyTypeState.Model), exception.Message);
         }
 
         [Fact]
@@ -155,5 +146,29 @@ namespace NetRx.Store.Tests
             Assert.Single(reducer.ReduceCalls.Where(c => c == typeof(SetItemsAction).FullName));
             Assert.Equal(1, effect.CallCount);
         }
+
+        [Fact]
+        public void Dispatch_Should_call_Reducer_Reduce_and_observable_should_invoke()
+        {
+            var reducer = new TestStateReducer();
+            var store = Store.Create()
+                .WithState(TestState.Initial, reducer);
+
+            var newObject = new ReferenceObect();
+            ReferenceObect selectedObect = null;
+
+            var disposable = store.Select<TestState, ReferenceObect>(f=> f.ReferenceObect)
+                .Subscribe(f => selectedObect = f);
+           
+            store.Dispatch(new SetReferenceObjectAction(newObject));
+
+            disposable.Dispose();
+
+            Assert.Same(newObject, selectedObect);
+            
+           
+        }
+
+
     }
 }

--- a/src/NetRx.Store/NetRx.Store.csproj
+++ b/src/NetRx.Store/NetRx.Store.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>NetRx</RootNamespace>
     <PackageId>NetRx.Store</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Vitalii Ilchenko</Authors>
     <Description>State management for .Net projects, inspired by @ngrx/store</Description>
     <RepositoryUrl>https://github.com/ilchenkob/NetRx.Store</RepositoryUrl>
@@ -17,6 +17,7 @@
   
   <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetRx.Store/NetRx.Store.csproj
+++ b/src/NetRx.Store/NetRx.Store.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>NetRx</RootNamespace>
     <PackageId>NetRx.Store</PackageId>
     <Version>2.1.0</Version>

--- a/src/NetRx.Store/NetRx.Store.csproj
+++ b/src/NetRx.Store/NetRx.Store.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>NetRx</RootNamespace>
     <PackageId>NetRx.Store</PackageId>
     <Version>2.0.0</Version>
@@ -20,10 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="System.Reactive" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetRx.Store/Store/StateWrapper.cs
+++ b/src/NetRx.Store/Store/StateWrapper.cs
@@ -93,11 +93,6 @@ namespace NetRx.Store
 
                 _gettersCache[OriginalTypeName].Add(name, getExpression.Compile());
 
-                if (!p.PropertyType.FullName.StartsWith("System.", StringComparison.InvariantCulture)
-                    && !isEnumerable)
-                {
-                    BuildGetters(p.PropertyType, name);
-                }
             }
         }
 

--- a/src/NetRx.Store/Store/StateWrapper.cs
+++ b/src/NetRx.Store/Store/StateWrapper.cs
@@ -10,6 +10,7 @@ namespace NetRx.Store
     internal sealed class StateWrapper
     {
         internal const string EnumerableFieldMarker = "#";
+        internal const string ReferenceFieldMarker = "*";
 
         private static readonly Dictionary<string, Dictionary<string, Func<object, object>>> _gettersCache
             = new Dictionary<string, Dictionary<string, Func<object, object>>>();
@@ -51,6 +52,8 @@ namespace NetRx.Store
             {
                 var isString = p.PropertyType == stringType;
                 var isEnumerable = p.PropertyType.GetInterface(typeof(IEnumerable<>).FullName) != null && !isString;
+                var isReferenceType = p.PropertyType.IsClass && !isString || (p.PropertyType.IsInterface && p.PropertyType.GetInterface(typeof(IEnumerable<>).FullName) == null);
+                
                 if (isEnumerable)
                 {
                     var hasImmutableInterface = p.PropertyType
@@ -65,10 +68,12 @@ namespace NetRx.Store
                         throw new InvalidStatePropertyTypeException(
                             $"'{p.Name}' cannot have reference type '{nonValueType.FullName}'. Should have 'struct' type");
                 }
-                else if (!p.PropertyType.IsValueType &&
+                else if (!isReferenceType &&
+                        !p.PropertyType.IsValueType &&
                           !isString &&
                           !isEnumerable)
                 {
+
                     throw new InvalidStatePropertyTypeException($"'{p.Name}' property of {prefix} cannot have reference type. Should have 'struct' type");
                 }
 
@@ -80,7 +85,11 @@ namespace NetRx.Store
                     wrappedObjectParameter
                 );
 
-                string name = isEnumerable ? $"{prefix}.{p.Name}{EnumerableFieldMarker}" : $"{prefix}.{p.Name}";
+                string name = isEnumerable 
+                    ? $"{prefix}.{p.Name}{EnumerableFieldMarker}"                     
+                    : isReferenceType 
+                        ? $"{prefix}.{p.Name}{ReferenceFieldMarker}"
+                        : $"{prefix}.{p.Name}";
 
                 _gettersCache[OriginalTypeName].Add(name, getExpression.Compile());
 
@@ -94,7 +103,11 @@ namespace NetRx.Store
 
         public object Get(string name)
         {
-            var key = _gettersCache[OriginalTypeName].ContainsKey(name) ? name : $"{name}{EnumerableFieldMarker}";
+            var key = _gettersCache[OriginalTypeName].ContainsKey(name) 
+                ? name 
+                :  _gettersCache[OriginalTypeName].ContainsKey($"{name}{EnumerableFieldMarker}") 
+                    ? $"{name}{EnumerableFieldMarker}"
+                    : $"{name}{ReferenceFieldMarker}";
 
             var propNamePart = key.Substring(OriginalTypeName.Length);
             var pointIndex = propNamePart.LastIndexOf('.');
@@ -124,6 +137,7 @@ namespace NetRx.Store
         public bool HasGeter(string name) =>
             _gettersCache[OriginalTypeName].ContainsKey(name) ||
                 _gettersCache[OriginalTypeName].ContainsKey($"{name}{EnumerableFieldMarker}") ||
+                _gettersCache[OriginalTypeName].ContainsKey($"{name}{ReferenceFieldMarker}") ||
                     string.Equals(name, OriginalTypeName);
 
         public object Original { get; private set; }

--- a/src/NetRx.Store/Store/Store.cs
+++ b/src/NetRx.Store/Store/Store.cs
@@ -184,10 +184,14 @@ namespace NetRx.Store
 
                         var hasChanges = field.EndsWith(StateWrapper.EnumerableFieldMarker, StringComparison.InvariantCulture)
                                               ? !Equals(newValue?.GetHashCode(), prevValue?.GetHashCode())
-                                              : !Equals(newValue, prevValue);
+                                              : field.EndsWith(StateWrapper.ReferenceFieldMarker, StringComparison.InvariantCulture)
+                                                ? !ReferenceEquals(newValue,prevValue)
+                                                : !Equals(newValue, prevValue);
                         if (hasChanges)
                         {
-                            NotifySubscribers(currState, field.Replace(StateWrapper.EnumerableFieldMarker, string.Empty));
+                            NotifySubscribers(currState, 
+                                field.Replace(StateWrapper.EnumerableFieldMarker, string.Empty)
+                                .Replace(StateWrapper.ReferenceFieldMarker, string.Empty));
                         }
                     }
                 }


### PR DESCRIPTION
Updated all Projects to Latest dotnet.

Update Store so that it will accept reference types and dispatch as required. It is better to allow the users to manage their immutable programming style.  
